### PR TITLE
Improved include path detection

### DIFF
--- a/guess-tex-master.el
+++ b/guess-tex-master.el
@@ -83,6 +83,17 @@ grep."
   :type 'boolean
   :group 'guess-TeX-master)
 
+(defcustom guess-TeX-master-default t
+  "Default guess if all else fails.
+Only applies if the guess-TeX-master-from-buffers and
+guess-TeX-master-from-files both fail.  Same choices as TeX-master variable."
+  :type '(choice (const :tag "Query" nil)
+                 (const :tag "This file" t)
+                 (const :tag "Shared" shared)
+                 (const :tag "Dwim" dwim)
+                 (string :format "%v"))
+  :group 'guess-TeX-master)
+
 (defvar TeX-master)
 
 (defun guess-TeX-master-from-files (filename)
@@ -127,7 +138,7 @@ variable TeX-master according to the guess, provided TeX-master is non-nil."
       (when guess-TeX-master-from-files
         (setq candidate (guess-TeX-master-from-files filename))))
     (unless candidate
-      (setq candidate TeX-master))
+      (setq candidate guess-TeX-master-default))
     (when (stringp candidate)
       (message "TeX master document: %s" (file-name-nondirectory candidate)))
     (unless TeX-master

--- a/guess-tex-master.el
+++ b/guess-tex-master.el
@@ -26,7 +26,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; 
 ;;; Change Log:
-;; 12-Dec-2011    Matthew L. Fidler  
+;; 12-Dec-2011    Matthew L. Fidler
 ;;    Last-Updated: Mon Dec 12 15:17:17 2011 (-0600) #55 (Matthew L. Fidler)
 ;;    Bugfix
 ;; 12-Dec-2011    Matthew L. Fidler
@@ -87,7 +87,7 @@ grep."
     ;; Unimplemented.
     master))
 
-(defun guess-TeX-master-from-buffer (filename)
+(defun guess-TeX-master-from-buffers (filename)
   "Guess TeX master for FILENAME from open .tex buffers."
   (let (candidate)
     (save-excursion
@@ -105,18 +105,23 @@ grep."
 
 ;;;###autoload
 (defun guess-TeX-master ()
-  "Guess the master file for FILENAME."
+  "Guess the master file for current buffer.
+Will check buffers, then files, then the TeX-master variable.  Sets a local
+variable TeX-master according to the guess, provided TeX-master is non-nil."
   (let* ((candidate nil)
-        (filename (buffer-file-name))
-        (filename (file-name-sans-extension (file-name-nondirectory filename))))
-    
+         (filename (buffer-file-name))
+         (filename (file-name-sans-extension (file-name-nondirectory filename))))
     (when guess-TeX-master-from-buffers
-      (setq candidate (guess-TeX-master-from-buffer filename)))
-    (setq candidate (guess-TeX-master-from-files filename))
-    (when candidate
-      (message "TeX master document: %s" (file-name-nondirectory candidate))
-      (unless TeX-master
-        (set (make-local-variable 'TeX-master) candidate)))))
+      (setq candidate (guess-TeX-master-from-buffers filename)))
+    (unless candidate
+      (when guess-TeX-master-from-files
+        (setq candidate (guess-TeX-master-from-files filename))))
+    (unless candidate
+      (setq candidate TeX-master))
+    (when (stringp candidate)
+      (message "TeX master document: %s" (file-name-nondirectory candidate)))
+    (unless TeX-master
+      (set (make-local-variable 'TeX-master) candidate))))
 
 ;;;###autoload
 (add-hook 'LaTeX-mode-hook 'guess-TeX-master)

--- a/guess-tex-master.el
+++ b/guess-tex-master.el
@@ -1,4 +1,4 @@
-;;; guess-tex-master.el --- Guess LaTeX Master File
+;;; guess-tex-master.el --- Guess LaTeX Master File -*- lexical-binding: t; -*-
 ;; 
 ;; Filename: guess-tex-master.el
 ;; Description: Guess LaTeX Master File
@@ -11,7 +11,7 @@
 ;;     Update #: 56
 ;; URL: https://github.com/mlf176f2/guess-tex-master.el
 ;; Keywords: AucTeX TeX-master
-;; Compatibility: 
+;; Compatibility:
 ;; 
 ;; Features that might be required by this library:
 ;;
@@ -19,7 +19,7 @@
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; 
-;;; Commentary: 
+;;; Commentary:
 ;; 
 ;;  
 ;; 
@@ -56,42 +56,44 @@
 ;;; Code:
 
 (defgroup guess-TeX-master nil
-  "Guess TeX Master from either the open files or files in the
-current directory.  Then optionally set the master file via a
-local variable."
+  "Guess TeX Master from either the open buffers or local files.
+Then optionally set the master file via a local variable."
   :group 'AUCTeX)
 
 (defcustom guess-TeX-master-includes '("input"
                                        "include"
                                        "makerubric")
-  "List of known LaTex includes"
+  "List of known LaTex includes."
   :type '(repeat (string :tag "Include Tag"))
   :group 'guess-TeX-master)
 
 (defcustom guess-TeX-master-from-buffers t
-  "Guess LaTeX Master from current buffer?"
+  "Guess LaTeX Master from currently open buffers."
   :type 'boolean
   :group 'guess-TeX-master)
 
 (defcustom guess-TeX-master-from-files t
-  "After failing to guess the TeX master from buffers, guess LaTeX master from current files? (Requires egrep)"
+  "Guess LaTeX Master from local files.
+Only applies if the guess-TeX-master-from-buffers fails.  Requires
+grep."
   :type 'boolean
   :group 'guess-TeX-master)
 
+(defvar TeX-master)
+
 (defun guess-TeX-master-from-files (filename)
-  "Guess TeX master from egrep list of files"
-  (let (val master)
+  "Guess TeX master for FILENAME from egrep list of files."
+  (let (master)
     ;; Unimplemented.
-  (symbol-value 'master)))
+    master))
 
 (defun guess-TeX-master-from-buffer (filename)
-  "Guesses TeX master from open .tex buffers"
+  "Guess TeX master for FILENAME from open .tex buffers."
   (let (candidate)
     (save-excursion
       (dolist (buffer (buffer-list))
         (with-current-buffer buffer
-          (let ((name (buffer-name))
-                (file buffer-file-name))
+          (let ((file buffer-file-name))
             (if (and file (string-match "\\.tex$" file))
                 (save-excursion
                   (goto-char (point-min))
@@ -99,11 +101,11 @@ local variable."
                                                    (regexp-opt guess-TeX-master-includes t)
                                                    "{" filename "\\([.]tex\\)?}") nil t)
                     (setq candidate file))))))))
-    (symbol-value 'candidate)))
+    candidate))
 
 ;;;###autoload
 (defun guess-TeX-master ()
-  "Guess the master file for FILENAME"
+  "Guess the master file for FILENAME."
   (let* ((candidate nil)
         (filename (buffer-file-name))
         (filename (file-name-sans-extension (file-name-nondirectory filename))))

--- a/guess-tex-master.el
+++ b/guess-tex-master.el
@@ -129,9 +129,10 @@ guess-TeX-master-from-files both fail.  Same choices as TeX-master variable."
 
 ;;;###autoload
 (defun guess-TeX-master ()
-  "Guess the master file for current buffer.
+  "Guess the master file for current buffer provided TeX-master is non-nil.
 Will check buffers, then files, then the TeX-master variable.  Sets a local
-variable TeX-master according to the guess, provided TeX-master is non-nil."
+variable TeX-master according to the guess."
+  (unless TeX-master
     (let ((candidate nil)
           (filename (buffer-file-name)))
       (when guess-TeX-master-from-buffers
@@ -143,7 +144,6 @@ variable TeX-master according to the guess, provided TeX-master is non-nil."
         (setq candidate guess-TeX-master-default))
       (when (stringp candidate)
         (message "TeX master document: %s" (file-name-nondirectory candidate)))
-    (unless TeX-master
       (set (make-local-variable 'TeX-master) candidate))))
 
 ;;;###autoload


### PR DESCRIPTION
I've updated the package to support more complex include calls. 

- The master file can now include files from other folders via relative paths. 
- Paths may include specifiers like dot, double dot or quotations marks (for paths with whitespaces)
- import and subimport now work as well (files are included as \import{<path>}{<filename>})
- If no master is found, a default guess can be specified via guess-TeX-master-default (to allow guessing "this file", for example)
- Flycheck was complaining about docstrings, lexical-binding and extra whitespaces, so I fixed those at the same time.

This is the first time I'm writing elisp for a package, so please excuse any amateur mistakes :)

EDIT:

- The newer commits consist of a few performance improvements to avoid unnecessary parsing.
- The last commit also implements the guess-TeX-master-from-files functionality using find and grep. Supports the same paths as guess-TeX-master-from-buffers